### PR TITLE
minor: fix typos in abstract, Eva's name, xsd:date datatypes

### DIFF
--- a/dpv.jsonld
+++ b/dpv.jsonld
@@ -2772,7 +2772,7 @@
         "@value": "Fajar J. Ekaputra"
       },
       {
-        "@value": "Eva Schlehan"
+        "@value": "Eva Schlehahn"
       },
       {
         "@value": "Elmar Kiesling"

--- a/dpv.n3
+++ b/dpv.n3
@@ -2762,7 +2762,7 @@ dpv:withdrawalTime a rdfs:Property ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/dpv.n3
+++ b/dpv.n3
@@ -2754,7 +2754,7 @@ dpv:withdrawalTime a rdfs:Property ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/dpv.ttl
+++ b/dpv.ttl
@@ -2762,7 +2762,7 @@ dpv:withdrawalTime a rdfs:Property ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/dpv.ttl
+++ b/dpv.ttl
@@ -2754,7 +2754,7 @@ dpv:withdrawalTime a rdfs:Property ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/dpv.xml
+++ b/dpv.xml
@@ -649,7 +649,7 @@
     <dct:contributor>Simon Steyskal</dct:contributor>
     <dct:contributor>Bud Bruegger</dct:contributor>
     <dct:contributor>Fajar J. Ekaputra</dct:contributor>
-    <dct:contributor>Eva Schlehan</dct:contributor>
+    <dct:contributor>Eva Schlehahn</dct:contributor>
     <dct:creator>Axel Polleres</dct:creator>
     <dct:abstract xml:lang="en">The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling according to the EU General Data Protection Regulation. This scope could be extended by later versions to other data and privacy protection regulations. The vocabulary provides terms to describe which personal data Categories are undergoing a specified kind of processing by a specific data controller and/or transferred to some recipient for a particular purpose , based on a specific legal ground (e.g. consent, or other legal grounds such as legitimate interest, etc.), with specified technical and organisational measures and restrictions (e.g. storage locations and storage durations) in place.</dct:abstract>
     <dct:contributor>Elmar Kiesling</dct:contributor>

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
           company: "OpenConsent/Kantara Initiative"
         },
         {
-          name: "Eva Schlehan",
+          name: "Eva Schlehahn",
           company: "Unabhängige Landeszentrum für Datenschutz Schleswig-Holstein"
         },
         {

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
 </head>
 <body>
   <section id="abstract">
-    <p>The Data Privacy Vocabulary (DPV) provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling according to the EU General Data Protection Regulation. This scope could be extended by later versions to other data and privacy protection regulations. The vocabulary provides terms to describe which personal data Categories are undergoing a specified kind of processing by a specific data controller and/or transferred to some recipient for a particular purpose, based on a specific legal ground (e.g., consent, or other legal grounds such as legitimate interest, etc.), with specified technical and organisational measures and restrictions (e.g., storage locations and storage durations) in place.</p>
+    <p>The Data Privacy Vocabulary (DPV) provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling according to the EU General Data Protection Regulation. This scope could be extended by later versions to other data and privacy protection regulations. The vocabulary provides terms to describe the specifics of: personal data undergoing processing by data controller(s) and/or transferred to some recipient for particular purpose(s), based on a specific legal bases (e.g., consent, or other legal grounds such as legitimate interest, etc.), with technical and organisational measures and restrictions (e.g., storage locations and storage durations) in place.</p>
     <p style="text-align: center;">The namespace for DPV terms is <code>http://www.w3.org/ns/dpv#</code></p>
     <p style="text-align: center;">The suggested prefix for the DPV namespace is <code>dpv</code></p>
     <p style="text-align: center;">The DPV ontology is available <a href="dpv.ttl">here</a>.</p>
@@ -188,7 +188,7 @@
       <li>Purposes</li>
       <li>Processing Categories</li>
       <li>Technical and Organisational Measures</li>
-      <li>Legal Basis</li>
+      <li>Legal Bases</li>
       <li>Consent</li>
       <li>Recipients, Data Controllers, Data Subjects</li>
     </ul>

--- a/rdf/BaseOntology.jsonld
+++ b/rdf/BaseOntology.jsonld
@@ -855,7 +855,7 @@
         "@value": "Rigo Wenning"
       },
       {
-        "@value": "Eva Schlehan"
+        "@value": "Eva Schlehahn"
       },
       {
         "@value": "Mark Lizar"

--- a/rdf/BaseOntology.n3
+++ b/rdf/BaseOntology.n3
@@ -181,7 +181,7 @@ dpv:hasTechnicalOrganisationalMeasure a rdfs:Property ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/BaseOntology.n3
+++ b/rdf/BaseOntology.n3
@@ -189,7 +189,7 @@ dpv:hasTechnicalOrganisationalMeasure a rdfs:Property ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/BaseOntology.ttl
+++ b/rdf/BaseOntology.ttl
@@ -181,7 +181,7 @@ dpv:hasTechnicalOrganisationalMeasure a rdfs:Property ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/BaseOntology.ttl
+++ b/rdf/BaseOntology.ttl
@@ -189,7 +189,7 @@ dpv:hasTechnicalOrganisationalMeasure a rdfs:Property ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/BaseOntology.xml
+++ b/rdf/BaseOntology.xml
@@ -18,7 +18,7 @@
   </rdfs:Class>
   <owl:Ontology rdf:about="https://w3.org/ns/dpv">
     <dct:contributor>Rigo Wenning</dct:contributor>
-    <dct:contributor>Eva Schlehan</dct:contributor>
+    <dct:contributor>Eva Schlehahn</dct:contributor>
     <dct:contributor>Mark Lizar</dct:contributor>
     <dct:contributor>Bert Bos</dct:contributor>
     <dct:creator>Axel Polleres</dct:creator>

--- a/rdf/Consent.jsonld
+++ b/rdf/Consent.jsonld
@@ -595,7 +595,7 @@
         "@value": "Rigo Wenning"
       },
       {
-        "@value": "Eva Schlehan"
+        "@value": "Eva Schlehahn"
       },
       {
         "@value": "Mark Lizar"

--- a/rdf/Consent.n3
+++ b/rdf/Consent.n3
@@ -151,7 +151,7 @@ dpv:withdrawalTime a rdfs:Property ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/Consent.n3
+++ b/rdf/Consent.n3
@@ -159,7 +159,7 @@ dpv:withdrawalTime a rdfs:Property ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/Consent.ttl
+++ b/rdf/Consent.ttl
@@ -151,7 +151,7 @@ dpv:withdrawalTime a rdfs:Property ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/Consent.ttl
+++ b/rdf/Consent.ttl
@@ -159,7 +159,7 @@ dpv:withdrawalTime a rdfs:Property ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/Consent.xml
+++ b/rdf/Consent.xml
@@ -42,7 +42,7 @@
     <dct:contributor>Fajar J. Ekaputra</dct:contributor>
     <dct:contributor>Bud Bruegger</dct:contributor>
     <dct:contributor>Rigo Wenning</dct:contributor>
-    <dct:contributor>Eva Schlehan</dct:contributor>
+    <dct:contributor>Eva Schlehahn</dct:contributor>
     <dct:title xml:lang="en">Data Privacy Vocabulary</dct:title>
     <vann:preferredNamespaceUri rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://w3.org/ns/dpv</vann:preferredNamespaceUri>
     <vann:preferredNamespacePrefix>dpv</vann:preferredNamespacePrefix>

--- a/rdf/PersonalDataCategory.jsonld
+++ b/rdf/PersonalDataCategory.jsonld
@@ -5408,7 +5408,7 @@
         "@value": "Rigo Wenning"
       },
       {
-        "@value": "Eva Schlehan"
+        "@value": "Eva Schlehahn"
       },
       {
         "@value": "Ramisa Gachpaz Hamed"

--- a/rdf/PersonalDataCategory.n3
+++ b/rdf/PersonalDataCategory.n3
@@ -1483,7 +1483,7 @@ dpv:WorkHistory a rdfs:Class ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/PersonalDataCategory.n3
+++ b/rdf/PersonalDataCategory.n3
@@ -1491,7 +1491,7 @@ dpv:WorkHistory a rdfs:Class ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/PersonalDataCategory.ttl
+++ b/rdf/PersonalDataCategory.ttl
@@ -1483,7 +1483,7 @@ dpv:WorkHistory a rdfs:Class ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/PersonalDataCategory.ttl
+++ b/rdf/PersonalDataCategory.ttl
@@ -1491,7 +1491,7 @@ dpv:WorkHistory a rdfs:Class ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/PersonalDataCategory.xml
+++ b/rdf/PersonalDataCategory.xml
@@ -172,7 +172,7 @@
     <dct:contributor>Elmar Kiesling</dct:contributor>
     <dct:contributor>Rigo Wenning</dct:contributor>
     <dct:description xml:lang="en">The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place.</dct:description>
-    <dct:contributor>Eva Schlehan</dct:contributor>
+    <dct:contributor>Eva Schlehahn</dct:contributor>
     <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-06-18</dct:created>
     <dct:contributor>Ramisa Gachpaz Hamed</dct:contributor>
     <dct:creator>Axel Polleres</dct:creator>

--- a/rdf/Processing.jsonld
+++ b/rdf/Processing.jsonld
@@ -1643,7 +1643,7 @@
         "@value": "Elmar Kiesling"
       },
       {
-        "@value": "Eva Schlehan"
+        "@value": "Eva Schlehahn"
       },
       {
         "@value": "Ramisa Gachpaz Hamed"

--- a/rdf/Processing.n3
+++ b/rdf/Processing.n3
@@ -350,7 +350,7 @@ dpv:isSystematicMonitoring a rdfs:Property ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/Processing.n3
+++ b/rdf/Processing.n3
@@ -358,7 +358,7 @@ dpv:isSystematicMonitoring a rdfs:Property ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/Processing.ttl
+++ b/rdf/Processing.ttl
@@ -350,7 +350,7 @@ dpv:isSystematicMonitoring a rdfs:Property ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/Processing.ttl
+++ b/rdf/Processing.ttl
@@ -358,7 +358,7 @@ dpv:isSystematicMonitoring a rdfs:Property ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/Processing.xml
+++ b/rdf/Processing.xml
@@ -21,7 +21,7 @@
     <dct:contributor>Elmar Kiesling</dct:contributor>
     <vann:preferredNamespaceUri rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://w3.org/ns/dpv</vann:preferredNamespaceUri>
     <dct:description xml:lang="en">The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place.</dct:description>
-    <dct:contributor>Eva Schlehan</dct:contributor>
+    <dct:contributor>Eva Schlehahn</dct:contributor>
     <vann:preferredNamespacePrefix>dpv</vann:preferredNamespacePrefix>
     <dct:creator>Axel Polleres</dct:creator>
     <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-06-18</dct:created>

--- a/rdf/Purpose.jsonld
+++ b/rdf/Purpose.jsonld
@@ -1435,7 +1435,7 @@
         "@value": "Rigo Wenning"
       },
       {
-        "@value": "Eva Schlehan"
+        "@value": "Eva Schlehahn"
       },
       {
         "@value": "Simon Steyskal"

--- a/rdf/Purpose.n3
+++ b/rdf/Purpose.n3
@@ -316,7 +316,7 @@ dpv:hasSector a rdfs:Property ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/Purpose.n3
+++ b/rdf/Purpose.n3
@@ -324,7 +324,7 @@ dpv:hasSector a rdfs:Property ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/Purpose.ttl
+++ b/rdf/Purpose.ttl
@@ -316,7 +316,7 @@ dpv:hasSector a rdfs:Property ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/Purpose.ttl
+++ b/rdf/Purpose.ttl
@@ -324,7 +324,7 @@ dpv:hasSector a rdfs:Property ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/Purpose.xml
+++ b/rdf/Purpose.xml
@@ -20,7 +20,7 @@
   <owl:Ontology rdf:about="https://w3.org/ns/dpv">
     <dct:contributor>Rigo Wenning</dct:contributor>
     <dct:title xml:lang="en">Data Privacy Vocabulary</dct:title>
-    <dct:contributor>Eva Schlehan</dct:contributor>
+    <dct:contributor>Eva Schlehahn</dct:contributor>
     <dct:contributor>Simon Steyskal</dct:contributor>
     <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0.1</owl:versionInfo>
     <dct:contributor>Elmar Kiesling</dct:contributor>

--- a/rdf/RecipientsDataControllersDataSubjects.jsonld
+++ b/rdf/RecipientsDataControllersDataSubjects.jsonld
@@ -56,7 +56,7 @@
     ],
     "http://purl.org/dc/terms/contributor": [
       {
-        "@value": "Eva Schlehan"
+        "@value": "Eva Schlehahn"
       },
       {
         "@value": "Simon Steyskal"

--- a/rdf/RecipientsDataControllersDataSubjects.n3
+++ b/rdf/RecipientsDataControllersDataSubjects.n3
@@ -41,7 +41,7 @@ dpv:ThirdParty a rdfs:Class ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/RecipientsDataControllersDataSubjects.n3
+++ b/rdf/RecipientsDataControllersDataSubjects.n3
@@ -49,7 +49,7 @@ dpv:ThirdParty a rdfs:Class ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/RecipientsDataControllersDataSubjects.ttl
+++ b/rdf/RecipientsDataControllersDataSubjects.ttl
@@ -41,7 +41,7 @@ dpv:ThirdParty a rdfs:Class ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/RecipientsDataControllersDataSubjects.ttl
+++ b/rdf/RecipientsDataControllersDataSubjects.ttl
@@ -49,7 +49,7 @@ dpv:ThirdParty a rdfs:Class ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/RecipientsDataControllersDataSubjects.xml
+++ b/rdf/RecipientsDataControllersDataSubjects.xml
@@ -10,7 +10,7 @@
 >
   <owl:Ontology rdf:about="https://w3.org/ns/dpv">
     <dct:creator>Axel Polleres</dct:creator>
-    <dct:contributor>Eva Schlehan</dct:contributor>
+    <dct:contributor>Eva Schlehahn</dct:contributor>
     <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0.1</owl:versionInfo>
     <dct:contributor>Simon Steyskal</dct:contributor>
     <vann:preferredNamespacePrefix>dpv</vann:preferredNamespacePrefix>

--- a/rdf/TechnicalOrganisationalMeasure.jsonld
+++ b/rdf/TechnicalOrganisationalMeasure.jsonld
@@ -1475,7 +1475,7 @@
         "@value": "Rigo Wenning"
       },
       {
-        "@value": "Eva Schlehan"
+        "@value": "Eva Schlehahn"
       }
     ],
     "http://purl.org/dc/terms/created": [

--- a/rdf/TechnicalOrganisationalMeasure.n3
+++ b/rdf/TechnicalOrganisationalMeasure.n3
@@ -326,7 +326,7 @@ dpv:storage a rdfs:Property ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/TechnicalOrganisationalMeasure.n3
+++ b/rdf/TechnicalOrganisationalMeasure.n3
@@ -334,7 +334,7 @@ dpv:storage a rdfs:Property ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/TechnicalOrganisationalMeasure.ttl
+++ b/rdf/TechnicalOrganisationalMeasure.ttl
@@ -326,7 +326,7 @@ dpv:storage a rdfs:Property ;
     dct:contributor "Bert Bos",
         "Bud Bruegger",
         "Elmar Kiesling",
-        "Eva Schlehan",
+        "Eva Schlehahn",
         "Fajar J. Ekaputra",
         "Javier D. Fernández",
         "Mark Lizar",

--- a/rdf/TechnicalOrganisationalMeasure.ttl
+++ b/rdf/TechnicalOrganisationalMeasure.ttl
@@ -334,7 +334,7 @@ dpv:storage a rdfs:Property ;
         "Rigo Wenning",
         "Rob Brennan",
         "Simon Steyskal" ;
-    dct:created "2019-06-18"^^xsd:dateTime ;
+    dct:created "2019-06-18"^^xsd:date ;
     dct:creator "Axel Polleres",
         "Harshvardhan J. Pandit" ;
     dct:description "The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling. These terms are intended to annotate Legal Personal Data Handling in a machine-readable fashion, by specifying which personal data categories are undergoing a specific kind of processing, by a specific data controller and/or shared with some recipient for a particular purpose , based on a specific legal ground (e.g. consent or legitimate interest), with specific technical and organisational measures and restrictions (e.g. storage location and storage duration) in place."@en ;

--- a/rdf/TechnicalOrganisationalMeasure.xml
+++ b/rdf/TechnicalOrganisationalMeasure.xml
@@ -184,7 +184,7 @@
     <dct:abstract xml:lang="en">The Data Privacy Vocabulary provides terms (classes and properties) to annotate and categorize instances of legally compliant personal data handling according to the EU General Data Protection Regulation. This scope could be extended by later versions to other data and privacy protection regulations. The vocabulary provides terms to describe which personal data Categories are undergoing a specified kind of processing by a specific data controller and/or transferred to some recipient for a particular purpose , based on a specific legal ground (e.g. consent, or other legal grounds such as legitimate interest, etc.), with specified technical and organisational measures and restrictions (e.g. storage locations and storage durations) in place.</dct:abstract>
     <dct:contributor>Rigo Wenning</dct:contributor>
     <vann:preferredNamespaceUri rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://w3.org/ns/dpv</vann:preferredNamespaceUri>
-    <dct:contributor>Eva Schlehan</dct:contributor>
+    <dct:contributor>Eva Schlehahn</dct:contributor>
     <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-06-18</dct:created>
   </owl:Ontology>
   <rdfs:Class rdf:about="http://w3.org/ns/dpv#Contract">


### PR DESCRIPTION
Also fixes a typo according to comments by Martin Kurze
https://lists.w3.org/Archives/Public/public-dpvcg/2019Jul/0038.html